### PR TITLE
Fix i18n in JS and PHP

### DIFF
--- a/src/ExpandableText.js
+++ b/src/ExpandableText.js
@@ -1,5 +1,6 @@
 import {Dashicon} from '@wordpress/components';
 import {useState} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 const ExpandableText = ({ text }) => {
     const [isExpanded, setIsExpanded] = useState(false);
@@ -21,12 +22,12 @@ const ExpandableText = ({ text }) => {
                         {isExpanded ? (
                             <span>
                                 <Dashicon icon={'arrow-up'} />
-                                {' read less'}
+                                {__( 'Read less', 'wp-rollback' )}
                             </span>
                         ) : (
                             <span>
                                 <Dashicon icon={'arrow-down'} />
-                                {' read more'}
+                                {__( 'Read more', 'wp-rollback' )}
                             </span>
                         )}
                     </span>

--- a/src/admin.js
+++ b/src/admin.js
@@ -149,7 +149,7 @@ const AdminPage = () => {
                     <a href={'https://wprollback.com/'} target={'_blank'}><img src={wprData.logo} width={250} height={'auto'} alt={'WP Rollback'}/></a>
                 </div>
 
-                <p className={'wpr-intro-text'}>{__( 'Select which version you would like to rollback to from the releases listed below.', '' )}</p>
+                <p className={'wpr-intro-text'}>{__( 'Select which version you would like to rollback to from the releases listed below.', 'wp-rollback' )}</p>
             </div>
             <div className="wpr-content-wrap">
                 {rollbackInfo.banners && queryArgs.type === 'plugin' && ( rollbackInfo.banners.high || rollbackInfo.banners.low ) && (

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,7 +1,7 @@
 import './admin.scss';
 import { Button, Dashicon, Modal, Spinner } from '@wordpress/components';
 import { render, useEffect, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import { decodeEntities } from '@wordpress/html-entities';
 import { getQueryArgs } from '@wordpress/url';
@@ -118,17 +118,23 @@ const AdminPage = () => {
         const diffInSeconds = Math.floor( ( now - date ) / 1000 );
 
         if ( diffInSeconds < 60 ) {
-            return `${diffInSeconds} seconds ago`;
+            // translators: %s Number of seconds.
+            return sprintf( _n( '%s second ago', '%s seconds ago', diffInSeconds, 'wp-rollback' ), diffInSeconds );
         } else if ( diffInSeconds < 3600 ) {
-            return `${Math.floor( diffInSeconds / 60 )} minutes ago`;
+            // translators: %s Number of minutes.
+            return sprintf( _n( '%s minute ago', '%s minutes ago', Math.floor( diffInSeconds / 60 ), 'wp-rollback' ), Math.floor( diffInSeconds / 60 ) );
         } else if ( diffInSeconds < 86400 ) {
-            return `${Math.floor( diffInSeconds / 3600 )} hours ago`;
+            // translators: %s Number of hours.
+            return sprintf( _n( '%s hour ago', '%s hours ago', Math.floor( diffInSeconds / 3600 ), 'wp-rollback' ), Math.floor( diffInSeconds / 3600 ) );
         } else if ( diffInSeconds < 2592000 ) { // 30 days
-            return `${Math.floor( diffInSeconds / 86400 )} days ago`;
+            // translators: %s Number of days.
+            return sprintf( _n( '%s day ago', '%s days ago', Math.floor( diffInSeconds / 86400 ), 'wp-rollback' ), Math.floor( diffInSeconds / 86400 ) );
         } else if ( diffInSeconds < 31536000 ) { // 365 days
-            return `${Math.floor( diffInSeconds / 2592000 )} months ago`;
+            // translators: %s Number of monthes.
+            return sprintf( _n( '%s month ago', '%s months ago', Math.floor( diffInSeconds / 2592000 ), 'wp-rollback' ), Math.floor( diffInSeconds / 2592000 ) );
         } else {
-            return `${Math.floor( diffInSeconds / 31536000 )} years ago`;
+            // translators: %s Number of years.
+            return sprintf( _n( '%s year ago', '%s years ago', Math.floor( diffInSeconds / 31536000 ), 'wp-rollback' ), Math.floor( diffInSeconds / 31536000 ) );
         }
     }
 
@@ -179,6 +185,7 @@ const AdminPage = () => {
                             {queryArgs.type === 'plugin' && (
                                 <a href={`https://wordpress.org/plugins/${rollbackInfo.slug}/`} target={'_blank'}
                                    className={'wpr-heading-link'}
+                                   // translators: %s Plugin or Theme name.
                                    alt={sprintf( __( 'View %s on WordPress.org', 'wp-rollback' ), rollbackInfo.name )}
                                 >
                                     {decodeEntities( rollbackInfo.name )}
@@ -188,6 +195,7 @@ const AdminPage = () => {
                             {queryArgs.type === 'theme' && (
                                 <a href={rollbackInfo.homepage} target={'_blank'}
                                    className={'wpr-heading-link'}
+                                   // translators: %s Plugin or Theme name.
                                    alt={sprintf( __( 'View %s on WordPress.org', 'wp-rollback' ), rollbackInfo.name )}>
                                     {decodeEntities( rollbackInfo.name )}
                                     <Dashicon icon="external"/>
@@ -242,7 +250,7 @@ const AdminPage = () => {
                                     <Button isSecondary onClick={openChangelogModal}
                                             className={'wpr-version-changelog'}>{__( 'View Changelog', 'wp-rollback' )}</Button>
                                 </div>
-                                <h3>Last Updated</h3>
+                                <h3>{__( 'Last Updated', 'wp-rollback' )}</h3>
                                 <div className={'wpr-updater-info'}>
                                     <Dashicon icon="clock"/>
                                     <span

--- a/wp-rollback.php
+++ b/wp-rollback.php
@@ -278,6 +278,7 @@ if ( ! class_exists( 'WP_Rollback' ) ) :
                 'avatarFallback'                  => plugins_url( 'src/assets/avatar-plugin-fallback.jpg', __FILE__ ),
                 'referrer'                => wp_get_referer(),
                 'text_no_changelog_found' => isset( $_GET['plugin_slug'] ) ? sprintf(
+                    // translators: %s Link.
                     __(
                         'Sorry, we couldn\'t find a changelog entry found for this version. Try checking the <a href="%s" target="_blank">developer log</a> on WP.org.',
                         'wp-rollback'


### PR DESCRIPTION
## Description
Add missing gettext to JS strings to allow translation.
Add missing comments to translators for strings with variables.
Add missing textdomain.

## How Has This Been Tested?
Built the package with npm run build.
Built the .pot with the new strings.
Translated all the new strings to Portuguese.
Built the json files for the JS translation.
The strings now appear translated as desired.

## Screenshots (jpeg or gifs if applicable):
![imagem](https://github.com/DevinWalker/wp-rollback/assets/7371591/510be67c-8fb5-4cac-9d13-dbccb9619c85)
![imagem](https://github.com/DevinWalker/wp-rollback/assets/7371591/59768d58-6c38-4933-b9aa-fe928399bab6)

## Types of changes
New strings for translation from JS code.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.